### PR TITLE
Add TLS support to built-in MQTT client

### DIFF
--- a/Assets/Scripts/SimpleMqttApplicationMessage.cs
+++ b/Assets/Scripts/SimpleMqttApplicationMessage.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Text;
+
+namespace RobotVoice.Mqtt
+{
+    public enum SimpleMqttQualityOfServiceLevel
+    {
+        AtMostOnce = 0,
+        AtLeastOnce = 1,
+        ExactlyOnce = 2
+    }
+
+    public sealed class SimpleMqttApplicationMessage
+    {
+        public string Topic { get; }
+        public byte[] Payload { get; }
+        public SimpleMqttQualityOfServiceLevel QualityOfServiceLevel { get; }
+
+        internal SimpleMqttApplicationMessage(string topic, byte[] payload, SimpleMqttQualityOfServiceLevel qos)
+        {
+            Topic = topic;
+            Payload = payload;
+            QualityOfServiceLevel = qos;
+        }
+    }
+
+    public sealed class SimpleMqttApplicationMessageBuilder
+    {
+        private string topic;
+        private byte[] payload = Array.Empty<byte>();
+        private SimpleMqttQualityOfServiceLevel qos = SimpleMqttQualityOfServiceLevel.AtMostOnce;
+
+        public SimpleMqttApplicationMessageBuilder WithTopic(string topic)
+        {
+            this.topic = topic;
+            return this;
+        }
+
+        public SimpleMqttApplicationMessageBuilder WithPayload(string payload)
+        {
+            if (payload == null)
+            {
+                this.payload = Array.Empty<byte>();
+            }
+            else
+            {
+                this.payload = Encoding.UTF8.GetBytes(payload);
+            }
+            return this;
+        }
+
+        public SimpleMqttApplicationMessageBuilder WithPayload(byte[] payload)
+        {
+            if (payload == null || payload.Length == 0)
+            {
+                this.payload = Array.Empty<byte>();
+            }
+            else
+            {
+                var copy = new byte[payload.Length];
+                Buffer.BlockCopy(payload, 0, copy, 0, payload.Length);
+                this.payload = copy;
+            }
+            return this;
+        }
+
+        public SimpleMqttApplicationMessageBuilder WithQualityOfServiceLevel(SimpleMqttQualityOfServiceLevel qos)
+        {
+            this.qos = qos;
+            return this;
+        }
+
+        public SimpleMqttApplicationMessage Build()
+        {
+            if (string.IsNullOrWhiteSpace(topic))
+            {
+                throw new InvalidOperationException("MQTT messages require a non-empty topic.");
+            }
+
+            return new SimpleMqttApplicationMessage(topic, payload, qos);
+        }
+    }
+}

--- a/Assets/Scripts/SimpleMqttApplicationMessage.cs.meta
+++ b/Assets/Scripts/SimpleMqttApplicationMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06b37ae64a1941d997922134f38831eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SimpleMqttClient.cs
+++ b/Assets/Scripts/SimpleMqttClient.cs
@@ -1,0 +1,602 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RobotVoice.Mqtt
+{
+    public sealed class SimpleMqttClient : IDisposable
+    {
+        private readonly SemaphoreSlim ioLock = new SemaphoreSlim(1, 1);
+        private readonly object stateLock = new object();
+
+        private TcpClient tcpClient;
+        private Stream stream;
+        private SimpleMqttClientOptions options;
+        private CancellationTokenSource keepAliveCts;
+        private Task keepAliveTask;
+        private ushort packetIdentifier = 1;
+        private bool disposed;
+
+        public bool IsConnected { get; private set; }
+
+        public event Action Connected;
+        public event Action<string> Disconnected;
+
+        public async Task ConnectAsync(SimpleMqttClientOptions options, CancellationToken cancellationToken)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            ThrowIfDisposed();
+
+            lock (stateLock)
+            {
+                if (IsConnected)
+                {
+                    return;
+                }
+
+                this.options = options;
+                packetIdentifier = 1;
+            }
+
+            tcpClient = new TcpClient();
+            try
+            {
+                await tcpClient.ConnectAsync(options.Host, options.Port).ConfigureAwait(false);
+                var networkStream = tcpClient.GetStream();
+                stream = await CreateTransportStreamAsync(networkStream, cancellationToken).ConfigureAwait(false);
+
+                await ioLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await SendConnectPacketAsync(cancellationToken).ConfigureAwait(false);
+                    var packet = await ReadPacketAsync(cancellationToken).ConfigureAwait(false);
+                    ValidateConnAck(packet);
+                }
+                finally
+                {
+                    ioLock.Release();
+                }
+
+                lock (stateLock)
+                {
+                    IsConnected = true;
+                }
+
+                Connected?.Invoke();
+                StartKeepAliveLoop();
+            }
+            catch
+            {
+                Cleanup("Connection failed");
+                throw;
+            }
+        }
+
+        public async Task PublishAsync(SimpleMqttApplicationMessage message, CancellationToken cancellationToken)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            ThrowIfDisposed();
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("MQTT client is not connected.");
+            }
+
+            await ioLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var packetId = await SendPublishPacketAsync(message, cancellationToken).ConfigureAwait(false);
+                if (message.QualityOfServiceLevel == SimpleMqttQualityOfServiceLevel.AtLeastOnce)
+                {
+                    var packet = await ReadPacketAsync(cancellationToken).ConfigureAwait(false);
+                    if ((packet.Header & 0xF0) != 0x40)
+                    {
+                        throw new InvalidOperationException("Expected PUBACK response from broker.");
+                    }
+
+                    if (packet.Payload.Length < 2)
+                    {
+                        throw new InvalidOperationException("PUBACK payload malformed.");
+                    }
+
+                    if (packetId.HasValue)
+                    {
+                        var ackId = (ushort)((packet.Payload[0] << 8) | packet.Payload[1]);
+                        if (ackId != packetId.Value)
+                        {
+                            throw new InvalidOperationException("PUBACK packet identifier mismatch.");
+                        }
+                    }
+                }
+                else if (message.QualityOfServiceLevel == SimpleMqttQualityOfServiceLevel.ExactlyOnce)
+                {
+                    throw new NotSupportedException("QoS 2 is not supported by SimpleMqttClient.");
+                }
+            }
+            catch
+            {
+                Cleanup("Publish failed");
+                throw;
+            }
+            finally
+            {
+                ioLock.Release();
+            }
+        }
+
+        public async Task DisconnectAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            if (!IsConnected)
+            {
+                Cleanup("Disconnected");
+                return;
+            }
+
+            await ioLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (stream != null)
+                {
+                    var packet = new byte[] { 0xE0, 0x00 };
+                    await stream.WriteAsync(packet, 0, packet.Length, cancellationToken).ConfigureAwait(false);
+                    await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch
+            {
+                Cleanup("Disconnect failed");
+                throw;
+            }
+            finally
+            {
+                ioLock.Release();
+            }
+
+            Cleanup("Disconnected");
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            Cleanup("Disposed");
+            ioLock.Dispose();
+        }
+
+        private void StartKeepAliveLoop()
+        {
+            var period = options?.KeepAlivePeriod ?? TimeSpan.Zero;
+            if (period <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            keepAliveCts?.Cancel();
+            keepAliveCts?.Dispose();
+
+            keepAliveCts = new CancellationTokenSource();
+            var token = keepAliveCts.Token;
+            keepAliveTask = Task.Run(() => KeepAliveLoopAsync(period, token), token);
+        }
+
+        private async Task KeepAliveLoopAsync(TimeSpan period, CancellationToken token)
+        {
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    await Task.Delay(period, token).ConfigureAwait(false);
+                    if (!IsConnected || token.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    await ioLock.WaitAsync(token).ConfigureAwait(false);
+                    try
+                    {
+                        await SendPingReqAsync(token).ConfigureAwait(false);
+                        var packet = await ReadPacketAsync(token).ConfigureAwait(false);
+                        if ((packet.Header & 0xF0) != 0xD0)
+                        {
+                            throw new InvalidOperationException("Expected PINGRESP from broker.");
+                        }
+                    }
+                    finally
+                    {
+                        ioLock.Release();
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch
+            {
+                Cleanup("KeepAlive failed");
+            }
+        }
+
+        private async Task<Stream> CreateTransportStreamAsync(NetworkStream networkStream, CancellationToken cancellationToken)
+        {
+            if (networkStream == null)
+            {
+                throw new ArgumentNullException(nameof(networkStream));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tlsOptions = options?.TlsOptions;
+            if (tlsOptions == null || !tlsOptions.UseTls)
+            {
+                return networkStream;
+            }
+
+            RemoteCertificateValidationCallback validationCallback = null;
+            if (tlsOptions.CertificateValidationCallback != null)
+            {
+                validationCallback = (_, certificate, chain, sslPolicyErrors) => tlsOptions.CertificateValidationCallback(certificate, chain, sslPolicyErrors);
+            }
+            else if (tlsOptions.AllowUntrustedCertificates)
+            {
+                validationCallback = (_, __, ___, ____) => true;
+            }
+
+            var sslStream = new SslStream(networkStream, false, validationCallback);
+            try
+            {
+                var targetHost = string.IsNullOrEmpty(tlsOptions.TargetHost) ? options.Host : tlsOptions.TargetHost;
+                var certificates = tlsOptions.ClientCertificates;
+                var protocols = tlsOptions.SslProtocols ?? SslProtocols.None;
+                var checkRevocation = tlsOptions.CheckCertificateRevocation;
+
+                await sslStream.AuthenticateAsClientAsync(targetHost, certificates, protocols, checkRevocation).ConfigureAwait(false);
+                return sslStream;
+            }
+            catch
+            {
+                sslStream.Dispose();
+                throw;
+            }
+        }
+
+        private async Task SendConnectPacketAsync(CancellationToken cancellationToken)
+        {
+            if (stream == null)
+            {
+                throw new InvalidOperationException("MQTT stream is not available.");
+            }
+
+            var hasUsername = !string.IsNullOrEmpty(options.Username);
+            var hasPassword = !string.IsNullOrEmpty(options.Password);
+            var variableHeader = new List<byte>();
+            variableHeader.AddRange(EncodeString("MQTT"));
+            variableHeader.Add(0x04); // Protocol level 3.1.1
+
+            byte connectFlags = 0;
+            if (options.CleanSession)
+            {
+                connectFlags |= 0x02;
+            }
+
+            if (hasUsername)
+            {
+                connectFlags |= 0x80;
+            }
+
+            if (hasPassword)
+            {
+                connectFlags |= 0x40;
+            }
+
+            variableHeader.Add(connectFlags);
+
+            var keepAliveSeconds = (ushort)Math.Min(ushort.MaxValue, Math.Max(0, (int)Math.Round(options.KeepAlivePeriod.TotalSeconds)));
+            variableHeader.Add((byte)(keepAliveSeconds >> 8));
+            variableHeader.Add((byte)(keepAliveSeconds & 0xFF));
+
+            var payload = new List<byte>();
+            payload.AddRange(EncodeString(string.IsNullOrEmpty(options.ClientId) ? Guid.NewGuid().ToString("N") : options.ClientId));
+            if (hasUsername)
+            {
+                payload.AddRange(EncodeString(options.Username));
+            }
+
+            if (hasPassword)
+            {
+                payload.AddRange(EncodeString(options.Password ?? string.Empty));
+            }
+
+            var remainingLength = variableHeader.Count + payload.Count;
+            var packet = new List<byte> { 0x10 };
+            packet.AddRange(EncodeRemainingLength(remainingLength));
+            packet.AddRange(variableHeader);
+            packet.AddRange(payload);
+
+            var buffer = packet.ToArray();
+            await stream.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<ushort?> SendPublishPacketAsync(SimpleMqttApplicationMessage message, CancellationToken cancellationToken)
+        {
+            if (stream == null)
+            {
+                throw new InvalidOperationException("MQTT stream is not available.");
+            }
+
+            var topicBytes = EncodeString(message.Topic);
+            var payload = message.Payload ?? Array.Empty<byte>();
+            byte header = 0x30; // PUBLISH
+            ushort? packetId = null;
+
+            switch (message.QualityOfServiceLevel)
+            {
+                case SimpleMqttQualityOfServiceLevel.AtMostOnce:
+                    break;
+                case SimpleMqttQualityOfServiceLevel.AtLeastOnce:
+                    header |= 0x02;
+                    packetId = GetNextPacketIdentifier();
+                    break;
+                case SimpleMqttQualityOfServiceLevel.ExactlyOnce:
+                    throw new NotSupportedException("QoS 2 is not supported by SimpleMqttClient.");
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            var remainingLength = topicBytes.Length + payload.Length;
+            if (packetId.HasValue)
+            {
+                remainingLength += 2;
+            }
+
+            var packet = new List<byte> { header };
+            packet.AddRange(EncodeRemainingLength(remainingLength));
+            packet.AddRange(topicBytes);
+            if (packetId.HasValue)
+            {
+                packet.Add((byte)(packetId.Value >> 8));
+                packet.Add((byte)(packetId.Value & 0xFF));
+            }
+
+            packet.AddRange(payload);
+            var buffer = packet.ToArray();
+            await stream.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            return packetId;
+        }
+
+        private async Task SendPingReqAsync(CancellationToken cancellationToken)
+        {
+            if (stream == null)
+            {
+                throw new InvalidOperationException("MQTT stream is not available.");
+            }
+
+            var packet = new byte[] { 0xC0, 0x00 };
+            await stream.WriteAsync(packet, 0, packet.Length, cancellationToken).ConfigureAwait(false);
+            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<MqttPacket> ReadPacketAsync(CancellationToken cancellationToken)
+        {
+            if (stream == null)
+            {
+                throw new InvalidOperationException("MQTT stream is not available.");
+            }
+
+            var header = await ReadExactAsync(1, cancellationToken).ConfigureAwait(false);
+            var remainingLength = await ReadRemainingLengthAsync(cancellationToken).ConfigureAwait(false);
+            var payload = remainingLength > 0 ? await ReadExactAsync(remainingLength, cancellationToken).ConfigureAwait(false) : Array.Empty<byte>();
+            return new MqttPacket(header[0], payload);
+        }
+
+        private async Task<int> ReadRemainingLengthAsync(CancellationToken cancellationToken)
+        {
+            var multiplier = 1;
+            var value = 0;
+            byte encodedByte;
+            var loops = 0;
+            do
+            {
+                var buffer = await ReadExactAsync(1, cancellationToken).ConfigureAwait(false);
+                encodedByte = buffer[0];
+                value += (encodedByte & 127) * multiplier;
+                multiplier *= 128;
+                loops++;
+                if (loops > 4)
+                {
+                    throw new InvalidOperationException("Malformed MQTT remaining length.");
+                }
+            }
+            while ((encodedByte & 128) != 0);
+
+            return value;
+        }
+
+        private async Task<byte[]> ReadExactAsync(int count, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[count];
+            var offset = 0;
+            while (offset < count)
+            {
+                var read = await stream.ReadAsync(buffer, offset, count - offset, cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    throw new IOException("MQTT connection closed by remote host.");
+                }
+
+                offset += read;
+            }
+
+            return buffer;
+        }
+
+        private ushort GetNextPacketIdentifier()
+        {
+            lock (stateLock)
+            {
+                if (packetIdentifier == 0)
+                {
+                    packetIdentifier = 1;
+                }
+
+                var id = packetIdentifier;
+                packetIdentifier++;
+                if (packetIdentifier == 0)
+                {
+                    packetIdentifier = 1;
+                }
+
+                return id;
+            }
+        }
+
+        private static byte[] EncodeString(string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
+            if (bytes.Length > ushort.MaxValue)
+            {
+                throw new InvalidOperationException("MQTT string exceeds maximum allowed length.");
+            }
+
+            var buffer = new byte[bytes.Length + 2];
+            buffer[0] = (byte)(bytes.Length >> 8);
+            buffer[1] = (byte)(bytes.Length & 0xFF);
+            Buffer.BlockCopy(bytes, 0, buffer, 2, bytes.Length);
+            return buffer;
+        }
+
+        private static byte[] EncodeRemainingLength(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            var bytes = new List<byte>();
+            do
+            {
+                var digit = value % 128;
+                value /= 128;
+                if (value > 0)
+                {
+                    digit |= 0x80;
+                }
+                bytes.Add((byte)digit);
+            }
+            while (value > 0);
+
+            return bytes.ToArray();
+        }
+
+        private void ValidateConnAck(MqttPacket packet)
+        {
+            if ((packet.Header & 0xF0) != 0x20)
+            {
+                throw new InvalidOperationException("Unexpected packet while waiting for CONNACK.");
+            }
+
+            if (packet.Payload.Length < 2)
+            {
+                throw new InvalidOperationException("Invalid CONNACK payload.");
+            }
+
+            var returnCode = packet.Payload[1];
+            if (returnCode != 0)
+            {
+                throw new InvalidOperationException($"MQTT broker rejected connection (code {returnCode}).");
+            }
+        }
+
+        private void Cleanup(string reason)
+        {
+            lock (stateLock)
+            {
+                var wasConnected = IsConnected;
+                IsConnected = false;
+
+                try
+                {
+                    keepAliveCts?.Cancel();
+                }
+                catch
+                {
+                }
+
+                keepAliveCts?.Dispose();
+                keepAliveCts = null;
+                keepAliveTask = null;
+
+                if (stream != null)
+                {
+                    try
+                    {
+                        stream.Dispose();
+                    }
+                    catch
+                    {
+                    }
+                    stream = null;
+                }
+
+                if (tcpClient != null)
+                {
+                    try
+                    {
+                        tcpClient.Close();
+                    }
+                    catch
+                    {
+                    }
+                    tcpClient = null;
+                }
+
+                if (wasConnected)
+                {
+                    Disconnected?.Invoke(reason ?? "Disconnected");
+                }
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(SimpleMqttClient));
+            }
+        }
+
+        private readonly struct MqttPacket
+        {
+            public MqttPacket(byte header, byte[] payload)
+            {
+                Header = header;
+                Payload = payload;
+            }
+
+            public byte Header { get; }
+            public byte[] Payload { get; }
+        }
+    }
+}

--- a/Assets/Scripts/SimpleMqttClient.cs.meta
+++ b/Assets/Scripts/SimpleMqttClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 163d0411230c46e0964dfe0f6dc90ed2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SimpleMqttClientOptions.cs
+++ b/Assets/Scripts/SimpleMqttClientOptions.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace RobotVoice.Mqtt
+{
+    public sealed class SimpleMqttClientOptions
+    {
+        public string Host { get; }
+        public int Port { get; }
+        public string ClientId { get; }
+        public bool CleanSession { get; }
+        public TimeSpan KeepAlivePeriod { get; }
+        public string Username { get; }
+        public string Password { get; }
+        public SimpleMqttTlsOptions TlsOptions { get; }
+
+        internal SimpleMqttClientOptions(
+            string host,
+            int port,
+            string clientId,
+            bool cleanSession,
+            TimeSpan keepAlivePeriod,
+            string username,
+            string password,
+            SimpleMqttTlsOptions tlsOptions)
+        {
+            Host = host;
+            Port = port;
+            ClientId = clientId;
+            CleanSession = cleanSession;
+            KeepAlivePeriod = keepAlivePeriod;
+            Username = username;
+            Password = password;
+            TlsOptions = tlsOptions ?? SimpleMqttTlsOptions.Disabled;
+        }
+    }
+
+    public sealed class SimpleMqttClientOptionsBuilder
+    {
+        private string host = "127.0.0.1";
+        private int port = 1883;
+        private string clientId = Guid.NewGuid().ToString("N");
+        private bool cleanSession = true;
+        private TimeSpan keepAlivePeriod = TimeSpan.FromSeconds(15);
+        private string username;
+        private string password;
+        private SimpleMqttTlsOptions tlsOptions = SimpleMqttTlsOptions.Disabled;
+
+        public SimpleMqttClientOptionsBuilder WithTcpServer(string host, int port = 1883)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                throw new ArgumentException("Host must be provided", nameof(host));
+            }
+
+            if (port <= 0 || port > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(port), "Port must be between 1 and 65535.");
+            }
+
+            this.host = host;
+            this.port = port;
+            return this;
+        }
+
+        public SimpleMqttClientOptionsBuilder WithClientId(string clientId)
+        {
+            if (!string.IsNullOrWhiteSpace(clientId))
+            {
+                this.clientId = clientId;
+            }
+            return this;
+        }
+
+        public SimpleMqttClientOptionsBuilder WithCleanSession(bool cleanSession = true)
+        {
+            this.cleanSession = cleanSession;
+            return this;
+        }
+
+        public SimpleMqttClientOptionsBuilder WithKeepAlivePeriod(TimeSpan keepAlivePeriod)
+        {
+            if (keepAlivePeriod < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(keepAlivePeriod), "KeepAlive must not be negative.");
+            }
+
+            this.keepAlivePeriod = keepAlivePeriod;
+            return this;
+        }
+
+        public SimpleMqttClientOptionsBuilder WithCredentials(string username, string password)
+        {
+            this.username = username;
+            this.password = password;
+            return this;
+        }
+
+        public SimpleMqttClientOptionsBuilder WithTls()
+        {
+            tlsOptions = SimpleMqttTlsOptions.CreateDefault();
+            return this;
+        }
+
+        public SimpleMqttClientOptionsBuilder WithTls(Action<SimpleMqttTlsOptionsBuilder> configure)
+        {
+            if (configure == null)
+            {
+                return WithTls();
+            }
+
+            var builder = new SimpleMqttTlsOptionsBuilder();
+            configure(builder);
+            tlsOptions = builder.Build();
+            return this;
+        }
+
+        public SimpleMqttClientOptionsBuilder WithoutTls()
+        {
+            tlsOptions = SimpleMqttTlsOptions.Disabled;
+            return this;
+        }
+
+        public SimpleMqttClientOptions Build()
+        {
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                throw new InvalidOperationException("MQTT host must be configured before building options.");
+            }
+
+            if (string.IsNullOrEmpty(clientId))
+            {
+                clientId = Guid.NewGuid().ToString("N");
+            }
+
+            return new SimpleMqttClientOptions(host, port, clientId, cleanSession, keepAlivePeriod, username, password, tlsOptions);
+        }
+    }
+
+    public sealed class SimpleMqttTlsOptions
+    {
+        private readonly X509CertificateCollection clientCertificates;
+
+        internal static SimpleMqttTlsOptions Disabled { get; } = new SimpleMqttTlsOptions(false, null, false, true, null, null, null);
+
+        internal static SimpleMqttTlsOptions CreateDefault()
+        {
+            return new SimpleMqttTlsOptions(true, null, false, true, null, null, null);
+        }
+
+        internal SimpleMqttTlsOptions(
+            bool useTls,
+            string targetHost,
+            bool allowUntrustedCertificates,
+            bool checkCertificateRevocation,
+            X509CertificateCollection clientCertificates,
+            Func<X509Certificate, X509Chain, SslPolicyErrors, bool> certificateValidationCallback,
+            SslProtocols? sslProtocols)
+        {
+            UseTls = useTls;
+            TargetHost = targetHost;
+            AllowUntrustedCertificates = allowUntrustedCertificates;
+            CheckCertificateRevocation = checkCertificateRevocation;
+            if (clientCertificates != null && clientCertificates.Count > 0)
+            {
+                this.clientCertificates = new X509CertificateCollection(clientCertificates);
+            }
+
+            CertificateValidationCallback = certificateValidationCallback;
+            SslProtocols = sslProtocols;
+        }
+
+        public bool UseTls { get; }
+        public string TargetHost { get; }
+        public bool AllowUntrustedCertificates { get; }
+        public bool CheckCertificateRevocation { get; }
+        public Func<X509Certificate, X509Chain, SslPolicyErrors, bool> CertificateValidationCallback { get; }
+        public SslProtocols? SslProtocols { get; }
+
+        public X509CertificateCollection ClientCertificates
+        {
+            get
+            {
+                if (clientCertificates == null)
+                {
+                    return new X509CertificateCollection();
+                }
+
+                return new X509CertificateCollection(clientCertificates);
+            }
+        }
+    }
+
+    public sealed class SimpleMqttTlsOptionsBuilder
+    {
+        private string targetHost;
+        private bool allowUntrustedCertificates;
+        private bool checkCertificateRevocation = true;
+        private SslProtocols? sslProtocols;
+        private Func<X509Certificate, X509Chain, SslPolicyErrors, bool> certificateValidationCallback;
+        private readonly List<X509Certificate> clientCertificates = new List<X509Certificate>();
+
+        public SimpleMqttTlsOptionsBuilder WithTargetHost(string host)
+        {
+            if (!string.IsNullOrWhiteSpace(host))
+            {
+                targetHost = host;
+            }
+
+            return this;
+        }
+
+        public SimpleMqttTlsOptionsBuilder AllowUntrustedCertificates(bool allow = true)
+        {
+            allowUntrustedCertificates = allow;
+            if (allow)
+            {
+                checkCertificateRevocation = false;
+            }
+
+            return this;
+        }
+
+        public SimpleMqttTlsOptionsBuilder CheckCertificateRevocation(bool check = true)
+        {
+            checkCertificateRevocation = check;
+            return this;
+        }
+
+        public SimpleMqttTlsOptionsBuilder WithSslProtocols(SslProtocols protocols)
+        {
+            sslProtocols = protocols;
+            return this;
+        }
+
+        public SimpleMqttTlsOptionsBuilder WithCertificateValidationCallback(Func<X509Certificate, X509Chain, SslPolicyErrors, bool> callback)
+        {
+            certificateValidationCallback = callback;
+            return this;
+        }
+
+        public SimpleMqttTlsOptionsBuilder WithClientCertificate(X509Certificate certificate)
+        {
+            if (certificate != null)
+            {
+                clientCertificates.Add(certificate);
+            }
+
+            return this;
+        }
+
+        public SimpleMqttTlsOptionsBuilder WithClientCertificates(IEnumerable<X509Certificate> certificates)
+        {
+            if (certificates == null)
+            {
+                return this;
+            }
+
+            foreach (var certificate in certificates)
+            {
+                if (certificate != null)
+                {
+                    clientCertificates.Add(certificate);
+                }
+            }
+
+            return this;
+        }
+
+        internal SimpleMqttTlsOptions Build()
+        {
+            X509CertificateCollection certificateCollection = null;
+            if (clientCertificates.Count > 0)
+            {
+                certificateCollection = new X509CertificateCollection();
+                foreach (var certificate in clientCertificates)
+                {
+                    certificateCollection.Add(certificate);
+                }
+            }
+
+            return new SimpleMqttTlsOptions(
+                true,
+                targetHost,
+                allowUntrustedCertificates,
+                checkCertificateRevocation,
+                certificateCollection,
+                certificateValidationCallback,
+                sslProtocols);
+        }
+    }
+}

--- a/Assets/Scripts/SimpleMqttClientOptions.cs.meta
+++ b/Assets/Scripts/SimpleMqttClientOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a89d57a0719c4d7ba0b97c6a80afb651
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ThirdParty/Plugins/MQTTnet/README.txt
+++ b/Assets/ThirdParty/Plugins/MQTTnet/README.txt
@@ -1,0 +1,13 @@
+This folder is reserved for the official MQTTnet library. The project already contains a
+first-party MQTT client capable of connecting, publishing intents (QoS 0/1) and handling
+keep-alive traffic, so you do not need any external DLLs to enable the MQTT intent publisher.
+
+If you prefer to use the full MQTTnet feature set (managed clients, subscriptions, TLS, etc.)
+download the Unity-compatible assemblies from the official project
+(https://github.com/dotnet/MQTTnet) and place them in this folder. Unity will import them on the
+next refresh. Recommended assemblies from the release package:
+- MQTTnet.dll
+- MQTTnet.Extensions.ManagedClient.dll (optional)
+
+After adding the DLLs, review the plugin import settings for each target platform to ensure they
+match your build requirements before swapping the publisher over to MQTTnet.

--- a/Assets/ThirdParty/Plugins/MQTTnet/README.txt.meta
+++ b/Assets/ThirdParty/Plugins/MQTTnet/README.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bf2f1f48fcdd40b9914fbd71723db976
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,18 @@ The project contains third‑party libraries inside the `Assets/ThirdParty` fold
 - **SimpleJSON** for JSON parsing
 - **Vosk** native libraries for Windows, macOS and Android
 
-No additional packages are required beyond the dependencies included in this repository.
+MQTT intent publishing (`ROBOTVOICE_USE_MQTT`) now ships with a first‑party client implementation, so
+no external DLLs are required for connecting to a broker, publishing intents with QoS 0/1, keeping
+the session alive or performing simple TLS handshakes. Simply enable the scripting define and
+configure the broker/TLS fields in `MqttIntentPublisher` to start sending intents.
+
+If your project requires more advanced MQTT features (subscriptions, managed clients, WebSockets,
+etc.) you can still drop the official [MQTTnet](https://github.com/dotnet/MQTTnet) assemblies into
+`Assets/ThirdParty/Plugins/MQTTnet/` and update the publisher to use them instead of the built‑in
+client.
+
+No additional packages are required beyond the dependencies included in this repository unless you
+choose to replace the bundled MQTT client with an alternative implementation.
 
 ## Importing
 


### PR DESCRIPTION
## Summary
- add TLS configuration support to the bundled SimpleMqttClient so it can perform TLS handshakes when connecting to secure brokers
- extend the client options/builder with TLS configuration helpers and expose matching inspector fields on MqttIntentPublisher
- document the new TLS workflow in the README

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d1c7d366108331b20700beead74d4e