### PR TITLE
Add pluggable speech engine support

### DIFF
--- a/Assets/Scripts/SpeechToTextEngine.cs
+++ b/Assets/Scripts/SpeechToTextEngine.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+/// <summary>
+/// Options passed to an <see cref="ISpeechToTextEngine"/> implementation during initialisation.
+/// </summary>
+public sealed class SpeechToTextEngineConfiguration
+{
+        /// <summary>
+        /// The absolute path to the model data used by the engine. Implementations decide how the path is consumed.
+        /// </summary>
+        public string ModelPath { get; }
+
+        /// <summary>
+        /// Optional key phrases that should be prioritised by the engine. May be empty.
+        /// </summary>
+        public IReadOnlyList<string> KeyPhrases { get; }
+
+        /// <summary>
+        /// Maximum number of alternative transcriptions the engine should keep track of.
+        /// </summary>
+        public int MaxAlternatives { get; }
+
+        /// <summary>
+        /// Audio sample rate, in hertz, expected by the engine.
+        /// </summary>
+        public float SampleRate { get; }
+
+        public SpeechToTextEngineConfiguration(string modelPath, IReadOnlyList<string> keyPhrases, int maxAlternatives, float sampleRate)
+        {
+                if (string.IsNullOrEmpty(modelPath))
+                        throw new ArgumentException("Model path must be a valid, non-empty string.", nameof(modelPath));
+
+                ModelPath = modelPath;
+                KeyPhrases = keyPhrases ?? Array.Empty<string>();
+                MaxAlternatives = Mathf.Max(1, maxAlternatives);
+                SampleRate = Mathf.Max(1f, sampleRate);
+        }
+}
+
+/// <summary>
+/// Provides a common contract for speech-to-text engines so that different providers can be plugged into the controller.
+/// </summary>
+public interface ISpeechToTextEngine : IDisposable
+{
+        /// <summary>
+        /// Human readable name for the engine. Used for logging and debugging.
+        /// </summary>
+        string EngineName { get; }
+
+        /// <summary>
+        /// Performs any heavy initialisation required before audio can be processed.
+        /// </summary>
+        Task InitialiseAsync(SpeechToTextEngineConfiguration configuration, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Attempts to transcribe the provided audio buffer.
+        /// </summary>
+        /// <param name="samples">Audio samples captured from the microphone.</param>
+        /// <param name="result">Full transcription if the engine produced a final result.</param>
+        /// <returns>True if a final transcription is ready, otherwise false.</returns>
+        bool TryRecognise(short[] samples, out string result);
+}
+
+/// <summary>
+/// Convenience base class that binds the <see cref="ISpeechToTextEngine"/> interface to a <see cref="MonoBehaviour"/>.
+/// </summary>
+public abstract class SpeechToTextEngineBase : MonoBehaviour, ISpeechToTextEngine
+{
+        public abstract string EngineName { get; }
+
+        public abstract Task InitialiseAsync(SpeechToTextEngineConfiguration configuration, CancellationToken cancellationToken = default);
+
+        public abstract bool TryRecognise(short[] samples, out string result);
+
+        public virtual void Dispose()
+        {
+        }
+}

--- a/Assets/Scripts/SpeechToTextEngine.cs.meta
+++ b/Assets/Scripts/SpeechToTextEngine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ceab44812374f1b99a95d85c977e65f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/VoskSpeechToText.cs
+++ b/Assets/Scripts/VoskSpeechToText.cs
@@ -9,8 +9,6 @@ using Ionic.Zip;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Networking;
-using UnityEngine.UI;
-using Vosk;
 
 public class VoskSpeechToText : MonoBehaviour
 {
@@ -22,39 +20,36 @@ public class VoskSpeechToText : MonoBehaviour
 	[Tooltip("The Max number of alternatives that will be processed.")]
 	public int MaxAlternatives = 3;
 
-	[Tooltip("How long should we record before restarting?")]
-	public float MaxRecordLength = 5;
+        [Tooltip("How long should we record before restarting?")]
+        public float MaxRecordLength = 5;
 
-	[Tooltip("Should the recognizer start when the application is launched?")]
-	public bool AutoStart = true;
+        [Tooltip("Should the recognizer start when the application is launched?")]
+        public bool AutoStart = true;
 
-	[Tooltip("The phrases that will be detected. If left empty, all words will be detected.")]
-	public List<string> KeyPhrases = new List<string>();
+        [Tooltip("The phrases that will be detected. If left empty, all words will be detected.")]
+        public List<string> KeyPhrases = new List<string>();
 
-	//Cached version of the Vosk Model.
-	private Model _model;
+        [Tooltip("Sample rate used for microphone capture and passed to the speech engine.")]
+        public int SampleRate = 16000;
 
-	//Cached version of the Vosk recognizer.
-	private VoskRecognizer _recognizer;
+        [Tooltip("Speech-to-text engine implementation. Defaults to the built-in Vosk engine when left empty.")]
+        [SerializeField]
+        private SpeechToTextEngineBase speechEngine;
 
-	//Conditional flag to see if a recognizer has already been created.
-	//TODO: Allow for runtime changes to the recognizer.
-	private bool _recognizerReady;
+        //Resolved engine instance used for recognition.
+        private SpeechToTextEngineBase _engineInstance;
 
-	//Holds all of the audio data until the user stops talking.
-	private readonly List<short> _buffer = new List<short>();
+        //Flag to indicate the engine has completed initialisation.
+        private bool _engineReady;
 
 	//Called when the the state of the controller changes.
 	public Action<string> OnStatusUpdated;
 
-	//Called after the user is done speaking and vosk processes the audio.
-	public Action<string> OnTranscriptionResult;
+        //Called after the user is done speaking and the speech engine processes the audio.
+        public Action<string> OnTranscriptionResult;
 
 	//The absolute path to the decompressed model folder.
 	private string _decompressedModelPath;
-
-	//A string that contains the keywords in Json Array format
-	private string _grammar = "";
 
 	//Flag that is used to wait for the model file to decompress successfully.
 	private bool _isDecompressing;
@@ -62,19 +57,57 @@ public class VoskSpeechToText : MonoBehaviour
 	//Flag that is used to wait for the the script to start successfully.
 	private bool _isInitializing;
 
-	//Flag that is used to check if Vosk was started.
-	private bool _didInit;
+        //Flag that is used to check if the speech engine was started.
+        private bool _didInit;
 
-	//Threading Logic
+        //Threading Logic
 
-	// Flag to signal we are ending
-	private bool _running;
+        // Flag to signal we are ending
+        private bool _running;
 
 	//Thread safe queue of microphone data.
 	private readonly ConcurrentQueue<short[]> _threadedBufferQueue = new ConcurrentQueue<short[]>();
 
-	//Thread safe queue of resuts
-	private readonly ConcurrentQueue<string> _threadedResultQueue = new ConcurrentQueue<string>();
+        //Thread safe queue of resuts
+        private readonly ConcurrentQueue<string> _threadedResultQueue = new ConcurrentQueue<string>();
+
+        private SpeechToTextEngineBase Engine
+        {
+                get
+                {
+                        if (_engineInstance == null)
+                        {
+                                _engineInstance = ResolveEngineInstance();
+                        }
+
+                        return _engineInstance;
+                }
+        }
+
+        public ISpeechToTextEngine CurrentEngine => Engine;
+
+        private SpeechToTextEngineBase ResolveEngineInstance()
+        {
+                if (speechEngine != null)
+                {
+                        return speechEngine;
+                }
+
+                var existing = GetComponent<SpeechToTextEngineBase>();
+                if (existing != null)
+                {
+                        speechEngine = existing;
+                        return existing;
+                }
+
+                speechEngine = gameObject.AddComponent<VoskSpeechToTextEngine>();
+                return speechEngine;
+        }
+
+        private int GetSampleRate()
+        {
+                return Mathf.Max(1, SampleRate);
+        }
         void Awake()
         {
                 if (VoiceProcessor == null)
@@ -85,104 +118,139 @@ public class VoskSpeechToText : MonoBehaviour
                                 VoiceProcessor = gameObject.AddComponent<VoiceProcessor>();
                         }
                 }
+
+                ResolveEngineInstance();
         }
 
 
 
 
-	static readonly ProfilerMarker voskRecognizerCreateMarker = new ProfilerMarker("VoskRecognizer.Create");
-	static readonly ProfilerMarker voskRecognizerReadMarker = new ProfilerMarker("VoskRecognizer.AcceptWaveform");
+        static readonly ProfilerMarker speechEngineProcessMarker = new ProfilerMarker("SpeechEngine.TryRecognise");
 
 	//If Auto start is enabled, starts vosk speech to text.
 	void Start()
 	{
 		//KeyPhrases = new List<string> { "forward", "backward", "left", "right" };
-		if (AutoStart)
-		{
-			StartVoskStt();
-		}
-	}
+                if (AutoStart)
+                {
+                        StartSpeechRecognition();
+                }
+        }
 
-	/// <summary>
-	/// Start Vosk Speech to text
-	/// </summary>
-	/// <param name="keyPhrases">A list of keywords/phrases. Keywords need to exist in the models dictionary, so some words like "webview" are better detected as two more common words "web view".</param>
-	/// <param name="modelPath">The path to the model folder relative to StreamingAssets. If the path has a .zip ending, it will be decompressed into the application data persistent folder.</param>
-	/// <param name="startMicrophone">"Should the microphone after vosk initializes?</param>
-	/// <param name="maxAlternatives">The maximum number of alternative phrases detected</param>
-	public void StartVoskStt(List<string> keyPhrases = null, string modelPath = default, bool startMicrophone = false, int maxAlternatives = 3)
-	{
-		if (_isInitializing)
-		{
-			Debug.LogError("Initializing in progress!");
-			return;
-		}
-		if (_didInit)
-		{
-			Debug.LogError("Vosk has already been initialized!");
-			return;
-		}
+        /// <summary>
+        /// Start speech recognition using the configured engine.
+        /// </summary>
+        /// <param name="keyPhrases">A list of keywords/phrases. Keywords need to exist in the model's dictionary.</param>
+        /// <param name="modelPath">The path to the model folder relative to StreamingAssets. If the path has a .zip ending, it will be decompressed into the application data persistent folder.</param>
+        /// <param name="startMicrophone">Should the microphone start recording immediately after initialisation?</param>
+        /// <param name="maxAlternatives">The maximum number of alternative phrases detected</param>
+        public void StartSpeechRecognition(List<string> keyPhrases = null, string modelPath = default, bool startMicrophone = false, int maxAlternatives = 3)
+        {
+                StartRecognitionInternal(keyPhrases, modelPath, startMicrophone, maxAlternatives);
+        }
 
-		if (!string.IsNullOrEmpty(modelPath))
-		{
-			ModelPath = modelPath;
-		}
+        /// <summary>
+        /// Backwards-compatible entry point for legacy scripts.
+        /// </summary>
+        public void StartVoskStt(List<string> keyPhrases = null, string modelPath = default, bool startMicrophone = false, int maxAlternatives = 3)
+        {
+                StartRecognitionInternal(keyPhrases, modelPath, startMicrophone, maxAlternatives);
+        }
 
-		if (keyPhrases != null)
-		{
-			KeyPhrases = keyPhrases;
-		}
+        private void StartRecognitionInternal(List<string> keyPhrases, string modelPath, bool startMicrophone, int maxAlternatives)
+        {
+                if (_isInitializing)
+                {
+                        Debug.LogError("Initializing in progress!");
+                        return;
+                }
+                if (_didInit)
+                {
+                        Debug.LogError("Speech engine has already been initialized!");
+                        return;
+                }
 
-		MaxAlternatives = maxAlternatives;
-		StartCoroutine(DoStartVoskStt(startMicrophone));
-	}
+                if (!string.IsNullOrEmpty(modelPath))
+                {
+                        ModelPath = modelPath;
+                }
+
+                if (keyPhrases != null)
+                {
+                        KeyPhrases = keyPhrases;
+                }
+
+                MaxAlternatives = maxAlternatives;
+                StartCoroutine(DoStartVoskStt(startMicrophone));
+        }
 
 	//Decompress model, load settings, start Vosk and optionally start the microphone
-	private IEnumerator DoStartVoskStt(bool startMicrophone)
-	{
-		_isInitializing = true;
-		yield return WaitForMicrophoneInput();
+        private IEnumerator DoStartVoskStt(bool startMicrophone)
+        {
+                _isInitializing = true;
+                _engineReady = false;
 
-		yield return Decompress();
+                yield return WaitForMicrophoneInput();
 
-		OnStatusUpdated?.Invoke("Loading Model from: " + _decompressedModelPath);
-		//Vosk.Vosk.SetLogLevel(0);
-		_model = new Model(_decompressedModelPath);
+                yield return Decompress();
 
-		yield return null;
+                var engine = Engine;
+                OnStatusUpdated?.Invoke($"Loading model ({engine.EngineName}) from: " + _decompressedModelPath);
 
-		OnStatusUpdated?.Invoke("Initialized");
-		VoiceProcessor.OnFrameCaptured += VoiceProcessorOnOnFrameCaptured;
-		VoiceProcessor.OnRecordingStop += VoiceProcessorOnOnRecordingStop;
+                int sampleRate = GetSampleRate();
 
-		if (startMicrophone)
-			VoiceProcessor.StartRecording();
+                SpeechToTextEngineConfiguration configuration = new SpeechToTextEngineConfiguration(
+                        _decompressedModelPath,
+                        KeyPhrases,
+                        MaxAlternatives,
+                        sampleRate);
 
-		_isInitializing = false;
-		_didInit = true;
+                Task initialiseTask;
+                try
+                {
+                        initialiseTask = engine.InitialiseAsync(configuration);
+                }
+                catch (Exception exception)
+                {
+                        Debug.LogError($"Failed to initialise speech engine {engine.EngineName}: {exception}");
+                        OnStatusUpdated?.Invoke($"Failed to initialise {engine.EngineName}.");
+                        _isInitializing = false;
+                        yield break;
+                }
 
-		ToggleRecording();
-	}
+                while (!initialiseTask.IsCompleted)
+                {
+                        yield return null;
+                }
 
-	//Translates the KeyPhraseses into a json array and appends the `[unk]` keyword at the end to tell vosk to filter other phrases.
-	private void UpdateGrammar()
-	{
-		if (KeyPhrases.Count == 0)
-		{
-			_grammar = "";
-			return;
-		}
+                if (initialiseTask.IsFaulted || initialiseTask.IsCanceled)
+                {
+                        Exception ex = initialiseTask.Exception?.GetBaseException();
+                        if (ex == null && initialiseTask.IsCanceled)
+                        {
+                                ex = new OperationCanceledException("Speech engine initialisation was cancelled.");
+                        }
 
-		JSONArray keywords = new JSONArray();
-		foreach (string keyphrase in KeyPhrases)
-		{
-			keywords.Add(new JSONString(keyphrase.ToLower()));
-		}
+                        Debug.LogError($"Failed to initialise speech engine {engine.EngineName}: {ex}");
+                        OnStatusUpdated?.Invoke($"Failed to initialise {engine.EngineName}.");
+                        _isInitializing = false;
+                        yield break;
+                }
 
-		keywords.Add(new JSONString("[unk]"));
+                _engineReady = true;
 
-		_grammar = keywords.ToString();
-	}
+                OnStatusUpdated?.Invoke($"Initialized ({engine.EngineName})");
+                VoiceProcessor.OnFrameCaptured += VoiceProcessorOnOnFrameCaptured;
+                VoiceProcessor.OnRecordingStop += VoiceProcessorOnOnRecordingStop;
+
+                if (startMicrophone)
+                        VoiceProcessor.StartRecording(sampleRate);
+
+                _isInitializing = false;
+                _didInit = true;
+
+                ToggleRecording();
+        }
 
 	//Decompress the model zip file or return the location of the decompressed files.
 	private IEnumerator Decompress()
@@ -266,23 +334,30 @@ public class VoskSpeechToText : MonoBehaviour
 	}
 
 	//Can be called from a script or a GUI button to start detection.
-	public void ToggleRecording()
-	{
-		Debug.Log("Toogle Recording");
-		if (!VoiceProcessor.IsRecording)
-		{
-			Debug.Log("Start Recording");
-			_running = true;
-			VoiceProcessor.StartRecording();
-    	                Task.Run(ThreadedWork).ConfigureAwait(false);
-		}
-		else
-		{
-			Debug.Log("Stop Recording");
-			_running = false;
-			VoiceProcessor.StopRecording();
-		}
-	}
+        public void ToggleRecording()
+        {
+                Debug.Log("Toogle Recording");
+                if (!VoiceProcessor.IsRecording)
+                {
+                        if (!_engineReady)
+                        {
+                                Debug.LogWarning("Speech engine is not initialised; call StartSpeechRecognition() first.");
+                                return;
+                        }
+
+                        Debug.Log("Start Recording");
+                        _running = true;
+                        int sampleRate = GetSampleRate();
+                        VoiceProcessor.StartRecording(sampleRate);
+                        Task.Run(ThreadedWork).ConfigureAwait(false);
+                }
+                else
+                {
+                        Debug.Log("Stop Recording");
+                        _running = false;
+                        VoiceProcessor.StopRecording();
+                }
+        }
 
 	//Calls the On Phrase Recognized event on the Unity Thread
 	void Update()
@@ -305,54 +380,68 @@ public class VoskSpeechToText : MonoBehaviour
                 Debug.Log("Stopped");
 	}
 
-	//Feeds the autio logic into the vosk recorgnizer
-	private async Task ThreadedWork()
-	{
-		voskRecognizerCreateMarker.Begin();
-		if (!_recognizerReady)
-		{
-			UpdateGrammar();
+        //Feeds the audio logic into the configured speech engine
+        private async Task ThreadedWork()
+        {
+                if (!_engineReady)
+                {
+                        Debug.LogWarning("Speech engine is not ready. Did you call StartSpeechRecognition()?");
+                        return;
+                }
 
-			//Only detect defined keywords if they are specified.
-			if (string.IsNullOrEmpty(_grammar))
-			{
-				_recognizer = new VoskRecognizer(_model, 16000.0f);
-			}
-			else
-			{
-				_recognizer = new VoskRecognizer(_model, 16000.0f, _grammar);
-			}
+                var engine = Engine;
 
-			_recognizer.SetMaxAlternatives(MaxAlternatives);
-			//_recognizer.SetWords(true);
-			_recognizerReady = true;
+                while (_running)
+                {
+                        if (_threadedBufferQueue.TryDequeue(out short[] voiceResult))
+                        {
+                                using (speechEngineProcessMarker.Auto())
+                                {
+                                        try
+                                        {
+                                                if (engine.TryRecognise(voiceResult, out string result))
+                                                {
+                                                        _threadedResultQueue.Enqueue(result);
+                                                }
+                                        }
+                                        catch (Exception exception)
+                                        {
+                                                Debug.LogError($"Speech engine {engine.EngineName} threw an exception: {exception}");
+                                        }
+                                }
+                        }
+                        else
+                        {
+                                // Wait for some data
+                                await Task.Delay(100).ConfigureAwait(false);
+                        }
+                }
+        }
 
-			Debug.Log("Recognizer ready");
-		}
+        private void OnDestroy()
+        {
+                _running = false;
+                _engineReady = false;
+                _didInit = false;
+                _isInitializing = false;
 
-		voskRecognizerCreateMarker.End();
+                if (VoiceProcessor != null)
+                {
+                        VoiceProcessor.OnFrameCaptured -= VoiceProcessorOnOnFrameCaptured;
+                        VoiceProcessor.OnRecordingStop -= VoiceProcessorOnOnRecordingStop;
 
-		voskRecognizerReadMarker.Begin();
+                        if (VoiceProcessor.IsRecording)
+                        {
+                                VoiceProcessor.StopRecording();
+                        }
+                }
 
-		while (_running)
-		{
-			if (_threadedBufferQueue.TryDequeue(out short[] voiceResult))
-			{
-				if (_recognizer.AcceptWaveform(voiceResult, voiceResult.Length))
-				{
-					var result = _recognizer.Result();
-					_threadedResultQueue.Enqueue(result);
-				}
-			}
-			else
-			{
-				// Wait for some data
-				await Task.Delay(100);
-			}
-		}
-
-		voskRecognizerReadMarker.End();
-	}
+                if (_engineInstance != null)
+                {
+                        _engineInstance.Dispose();
+                        _engineInstance = null;
+                }
+        }
 
 
 

--- a/Assets/Scripts/VoskSpeechToTextEngine.cs
+++ b/Assets/Scripts/VoskSpeechToTextEngine.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SimpleJSON;
+using UnityEngine;
+using Vosk;
+
+/// <summary>
+/// Default speech-to-text engine using the bundled Vosk bindings.
+/// Additional engines can be created by inheriting from <see cref="SpeechToTextEngineBase"/>.
+/// </summary>
+[DisallowMultipleComponent]
+public class VoskSpeechToTextEngine : SpeechToTextEngineBase
+{
+        private readonly object _syncRoot = new object();
+        private Model _model;
+        private VoskRecognizer _recognizer;
+
+        public override string EngineName => "Vosk";
+
+        public override async Task InitialiseAsync(SpeechToTextEngineConfiguration configuration, CancellationToken cancellationToken = default)
+        {
+                if (configuration == null)
+                        throw new ArgumentNullException(nameof(configuration));
+
+                await Task.Run(() =>
+                {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        lock (_syncRoot)
+                        {
+                                DisposeInternal();
+
+                                _model = new Model(configuration.ModelPath);
+
+                                string grammar = BuildGrammar(configuration.KeyPhrases);
+                                if (string.IsNullOrEmpty(grammar))
+                                {
+                                        _recognizer = new VoskRecognizer(_model, configuration.SampleRate);
+                                }
+                                else
+                                {
+                                        _recognizer = new VoskRecognizer(_model, configuration.SampleRate, grammar);
+                                }
+
+                                _recognizer.SetMaxAlternatives(configuration.MaxAlternatives);
+                        }
+                }, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override bool TryRecognise(short[] samples, out string result)
+        {
+                result = null;
+                if (samples == null)
+                        return false;
+
+                lock (_syncRoot)
+                {
+                        if (_recognizer == null)
+                                return false;
+
+                        if (_recognizer.AcceptWaveform(samples, samples.Length))
+                        {
+                                result = _recognizer.Result();
+                                return true;
+                        }
+                }
+
+                return false;
+        }
+
+        public override void Dispose()
+        {
+                lock (_syncRoot)
+                {
+                        DisposeInternal();
+                }
+        }
+
+        private static string BuildGrammar(IReadOnlyList<string> keyPhrases)
+        {
+                if (keyPhrases == null || keyPhrases.Count == 0)
+                        return string.Empty;
+
+                JSONArray keywords = new JSONArray();
+                foreach (var keyphrase in keyPhrases)
+                {
+                        if (string.IsNullOrWhiteSpace(keyphrase))
+                                continue;
+
+                        keywords.Add(new JSONString(keyphrase.ToLowerInvariant()));
+                }
+
+                if (keywords.Count == 0)
+                        return string.Empty;
+
+                keywords.Add(new JSONString("[unk]"));
+                return keywords.ToString();
+        }
+
+        private void DisposeInternal()
+        {
+                _recognizer?.Dispose();
+                _recognizer = null;
+
+                _model?.Dispose();
+                _model = null;
+        }
+}

--- a/Assets/Scripts/VoskSpeechToTextEngine.cs.meta
+++ b/Assets/Scripts/VoskSpeechToTextEngine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e56a165e965840289ed8bd9c46fb96b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vosk Unity Package
 
-Offline speech recognition using the [Vosk](https://github.com/alphacep/vosk-api) library.
+Offline speech recognition using the [Vosk](https://github.com/alphacep/vosk-api) library with a pluggable speech-to-text engine pipeline.
 
 ## Requirements
 
@@ -34,17 +34,18 @@ After opening the project Unity will import the native plugins for your platform
 
 ## ModelPath
 
-`VoskSpeechToText` expects a model archive inside the **StreamingAssets** folder. The `ModelPath` field contains the relative path (e.g. `vosk-model-small-en-us-0.15.zip`). On the first run the archive is extracted to `Application.persistentDataPath`.
+`VoskSpeechToText` expects a model archive inside the **StreamingAssets** folder when the built-in Vosk engine is used. The `ModelPath` field contains the relative path (e.g. `vosk-model-small-en-us-0.15.zip`). On the first run the archive is extracted to `Application.persistentDataPath`.
 
-You can assign a different model by changing `ModelPath` in the inspector or through script before calling `StartVoskStt`.
+You can assign a different model by changing `ModelPath` in the inspector or through script before calling `StartSpeechRecognition` (or the legacy `StartVoskStt`). Custom engines may choose to interpret the model path differently, so consult the engine's documentation.
 
 ## Usage
 
 1. Add the **VoskSpeechToText** component to a GameObject in your scene.
-2. Place a Vosk model archive into `Assets/StreamingAssets/` and assign its filename to `ModelPath`.
-3. A `VoiceProcessor` component is required for microphone input. If one isn't present on the same GameObject, `VoskSpeechToText` adds it automatically.
-4. Call `StartVoskStt` (optionally with `startMicrophone: true`) to initialise the recogniser.
-5. Subscribe to `OnTranscriptionResult` to receive the recognised text.
+2. (Optional) Add a component that inherits from `SpeechToTextEngineBase` to the same GameObject and assign it to the **Speech Engine** field. If left empty the default `VoskSpeechToTextEngine` is created automatically.
+3. Provide the model assets required by the engine (for Vosk this means copying the archive into `Assets/StreamingAssets/` and assigning its filename to `ModelPath`) and adjust the `Sample Rate` field if your engine expects a different capture rate.
+4. A `VoiceProcessor` component is required for microphone input. If one isn't present on the same GameObject, `VoskSpeechToText` adds it automatically.
+5. Call `StartSpeechRecognition` (optionally with `startMicrophone: true`) to initialise the recogniser. The legacy `StartVoskStt` method remains available for existing integrations.
+6. Subscribe to `OnTranscriptionResult` to receive the recognised text.
 
 ```csharp
 using UnityEngine;
@@ -57,10 +58,29 @@ public class VoskExample : MonoBehaviour
     {
         speech.ModelPath = "vosk-model-small-en-us-0.15.zip"; // relative to StreamingAssets
         speech.OnTranscriptionResult += result => Debug.Log(result);
-        speech.StartVoskStt(startMicrophone: true);
+        speech.StartSpeechRecognition(startMicrophone: true);
     }
 }
 ```
+
+## Creating custom speech engines
+
+`VoskSpeechToText` delegates audio processing to components that inherit from `SpeechToTextEngineBase`. The built-in
+`VoskSpeechToTextEngine` is provided for backwards compatibility, but you can plug in alternative providers (including online
+services or other offline SDKs) by implementing the following contract:
+
+1. Create a new `MonoBehaviour` that inherits from `SpeechToTextEngineBase` and override the `EngineName`,
+   `InitialiseAsync` and `TryRecognise` members.
+2. Use the supplied `SpeechToTextEngineConfiguration` to load your model assets. The configuration includes the resolved
+   model path, requested key phrases, maximum alternatives and the microphone sample rate.
+3. Add your component to the same GameObject as `VoskSpeechToText` and assign it to the **Speech Engine** field in the
+   inspector.
+4. Call `StartSpeechRecognition` as usual. The controller will invoke your engine instead of the default Vosk
+   implementation.
+
+This design makes it possible to experiment with Hugging Face, Azure, Google Cloud or any other service without modifying
+the controller. Each engine controls its own initialisation and waveform processing pipeline while the controller handles
+microphone management and result dispatching.
 
 ## Hello World Example
 
@@ -76,7 +96,7 @@ public class HelloWorldExample : MonoBehaviour
     void Start()
     {
         speech.OnTranscriptionResult += OnResult;
-        speech.StartVoskStt(startMicrophone: true);
+        speech.StartSpeechRecognition(startMicrophone: true);
     }
 
     void OnResult(string json)


### PR DESCRIPTION
## Summary
- introduce an extensible speech-to-text engine abstraction and default Vosk implementation
- refactor VoskSpeechToText to consume the new engine contract, add configurable sample rate and improved lifecycle handling
- update documentation to describe the new workflow and how to plug in alternative engines

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d4139ba8388331ab629eb507f5234c