### PR TITLE
Ensure game launches in exclusive fullscreen

### DIFF
--- a/Assets/Scripts/VoiceGameLauncher.cs
+++ b/Assets/Scripts/VoiceGameLauncher.cs
@@ -27,6 +27,7 @@ namespace RobotVoice
 
         private void Awake()
         {
+            ApplyFullscreenMode();
             runtimeConfig = BuildRuntimeConfig();
             ApplySpeechKeyPhrases();
         }
@@ -38,6 +39,18 @@ namespace RobotVoice
             ApplySpeechKeyPhrases();
         }
 #endif
+
+        private void ApplyFullscreenMode()
+        {
+            if (Application.isEditor)
+            {
+                return;
+            }
+
+            var resolution = Screen.currentResolution;
+            Screen.fullScreenMode = FullScreenMode.ExclusiveFullScreen;
+            Screen.SetResolution(resolution.width, resolution.height, true);
+        }
 
         private VoiceIntentConfig BuildRuntimeConfig()
         {


### PR DESCRIPTION
## Summary
- configure the game launcher to switch into exclusive fullscreen mode on startup
- set the resolution to match the current display when entering fullscreen

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da8b70fe448331af62957449261d30