### PR TITLE
Improve fullscreen enforcement

### DIFF
--- a/Assets/Scripts/VoiceGameLauncher.cs
+++ b/Assets/Scripts/VoiceGameLauncher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -27,8 +28,19 @@ namespace RobotVoice
 
         private void Awake()
         {
+            ApplyFullscreenMode();
             runtimeConfig = BuildRuntimeConfig();
             ApplySpeechKeyPhrases();
+        }
+
+        private void Start()
+        {
+            if (Application.isEditor)
+            {
+                return;
+            }
+
+            StartCoroutine(EnsureFullscreenAfterFirstFrame());
         }
 
 #if UNITY_EDITOR
@@ -38,6 +50,34 @@ namespace RobotVoice
             ApplySpeechKeyPhrases();
         }
 #endif
+
+        private void ApplyFullscreenMode()
+        {
+            if (Application.isEditor)
+            {
+                return;
+            }
+
+            var resolution = Screen.currentResolution;
+            Screen.fullScreenMode = FullScreenMode.ExclusiveFullScreen;
+            Screen.SetResolution(
+                resolution.width,
+                resolution.height,
+                FullScreenMode.ExclusiveFullScreen,
+                resolution.refreshRate
+            );
+
+            if (!Screen.fullScreen)
+            {
+                Screen.fullScreen = true;
+            }
+        }
+
+        private IEnumerator EnsureFullscreenAfterFirstFrame()
+        {
+            yield return null;
+            ApplyFullscreenMode();
+        }
 
         private VoiceIntentConfig BuildRuntimeConfig()
         {


### PR DESCRIPTION
## Summary
- defer a fullscreen re-application until the first rendered frame to prevent minimized startup
- switch to the overload of Screen.SetResolution that requests exclusive fullscreen with the current refresh rate
- explicitly enable Screen.fullScreen when entering exclusive fullscreen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8b70fe448331af62957449261d30