### PR TITLE
Fix voice intent example synonyms

### DIFF
--- a/Assets/Scripts/voice_intents.example.json
+++ b/Assets/Scripts/voice_intents.example.json
@@ -3,8 +3,17 @@
   "LaunchKeywords": ["open", "play"],
   "ExitKeywords": ["quit", "close"],
   "SynonymOverrides": [
-    { "Spoken": "notebook", "GameName": "Notebook" },
-    { "Spoken": "flippy bird", "GameName": "Flippy Bird" },
-    { "Spoken": "slow boat", "GameName": "Slow Boat" }
+    {
+      "Canonical": "Notebook",
+      "Variants": ["notebook"]
+    },
+    {
+      "Canonical": "Flappy Bird",
+      "Variants": ["flappy bird", "flappybird"]
+    },
+    {
+      "Canonical": "Slow Boat",
+      "Variants": ["slow boat", "slowboat"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- update the sample voice intent configuration to match the SynonymOverride schema
- provide canonical game names with variant spellings so they are added to the keyword list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae361a0088331b69df4d788e006c4