### PR TITLE
Add Faster-Whisper speech service integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,8 @@ crashlytics-build.properties
 /[Uu]serSettings/Layouts/default-2021.dwlt
 /[Uu]serSettings/Layouts/default-2021.dwlt.meta
 
+# Python virtual environments & caches
+python_voice_service/.venv/
+python_voice_service/__pycache__/
+python_voice_service/.pytest_cache/
+

--- a/Assets/Scene/agent.unity
+++ b/Assets/Scene/agent.unity
@@ -236,9 +236,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f217616079a9a74489a1ae3cd9178787, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ModelPath: vosk-model-small-en-us-0.15.zip
+  UsePythonService: 1
+  PythonServiceUrl: http://127.0.0.1:8000/transcribe
+  PythonServiceLanguage:
+  PythonServiceBeamSize: 5
   VoiceProcessor: {fileID: 1558954883}
   MaxAlternatives: 3
   MaxRecordLength: 5
@@ -342,12 +346,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cf39116cc6db44d47b2eaf534e0f6682, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   MicrophoneIndex: 0
   _minimumSpeakingSampleValue: 0.05
   _silenceTimer: 1
-  _autoDetect: 0
+  _autoDetect: 1
 --- !u!4 &1558954884
 Transform:
   m_ObjectHideFlags: 0

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ public class VoskExample : MonoBehaviour
 }
 ```
 
+## Python Voice Service
+
+The project now supports streaming microphone audio to an external Python
+service that runs [Faster-Whisper](https://github.com/guillaumekln/faster-whisper).
+Enable **Use Python Service** on the `VoskSpeechToText` component and set
+`PythonServiceUrl` to the `transcribe` endpoint exposed by the service
+(defaults to `http://127.0.0.1:8000/transcribe`). See
+[`python_voice_service/README.md`](python_voice_service/README.md) for
+setup instructions, including pointing the service at the downloaded
+model directory shown in the screenshots.
+
 ## Hello World Example
 
 The following example shows how to detect the word `"hello"` and print `"hello world"` to the console.

--- a/python_voice_service/README.md
+++ b/python_voice_service/README.md
@@ -1,0 +1,55 @@
+# Python Voice Service
+
+This folder contains a lightweight FastAPI application that wraps the
+[Faster-Whisper](https://github.com/guillaumekln/faster-whisper) model
+so Unity can offload speech recognition to Python. The REST endpoint
+returns Vosk-compatible JSON payloads, allowing the existing
+`VoiceGameLauncher` logic to keep publishing intents to the message hub
+without any changes.
+
+## Requirements
+
+* Python 3.10 or newer
+* The Faster-Whisper model weights downloaded to your machine. The
+  screenshot in the task corresponds to a folder such as
+  `D:/Data/unityproject/faster-whisper-large-v3` on Windows. Set the
+  `WHISPER_MODEL_PATH` environment variable to that directory before
+  starting the service.
+
+Install dependencies with:
+
+```bash
+python -m venv .venv
+.venv\\Scripts\\activate  # On PowerShell / cmd use .venv\Scripts\activate.bat
+pip install -r requirements.txt
+```
+
+> **Tip:** On macOS/Linux activate the virtual environment with
+> `source .venv/bin/activate`.
+
+## Running the service
+
+1. Export the environment variables that control model loading:
+
+   ```bash
+   export WHISPER_MODEL_PATH="/path/to/faster-whisper-large-v3"
+   export WHISPER_DEVICE=cpu          # or "cuda" if you have GPU support
+   export WHISPER_COMPUTE_TYPE=int8   # tweak if you use CUDA (e.g. float16)
+   ```
+
+   On Windows PowerShell replace `export` with `$env:VAR = "value"`.
+
+2. Start the API:
+
+   ```bash
+   uvicorn main:app --host 0.0.0.0 --port 8000
+   ```
+
+   The Unity scene expects the default URL `http://127.0.0.1:8000/transcribe`.
+
+3. Use the `/healthz` endpoint to confirm the service is ready.
+
+When Unity detects speech the `VoskSpeechToText` component serialises the
+PCM samples, posts them to `/transcribe` and reuses the JSON response to
+update the intent pipeline. No scene changes are required to keep
+publishing to the MQTT message hub.

--- a/python_voice_service/main.py
+++ b/python_voice_service/main.py
@@ -1,0 +1,152 @@
+"""Python voice service using Faster-Whisper for speech recognition.
+
+This module exposes a FastAPI application that accepts raw PCM audio
+from the Unity client, performs transcription with Faster-Whisper and
+returns a Vosk-compatible JSON payload so the rest of the Unity project
+can reuse the existing message hub pipeline.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from functools import lru_cache
+from typing import Iterable, List, Optional
+
+import numpy as np
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+from faster_whisper import WhisperModel
+
+APP_TITLE = "Coach Voice Agent - Python Voice Service"
+DEFAULT_SAMPLE_RATE = 16000
+
+app = FastAPI(title=APP_TITLE)
+
+
+def _environment(key: str, default: str) -> str:
+    value = os.getenv(key)
+    return value.strip() if value is not None else default
+
+
+@lru_cache(maxsize=1)
+def _load_model() -> WhisperModel:
+    model_path = _environment("WHISPER_MODEL_PATH", "./models/faster-whisper-large-v3")
+    device = _environment("WHISPER_DEVICE", "cpu")
+    compute_type = _environment("WHISPER_COMPUTE_TYPE", "int8")
+
+    if not os.path.exists(model_path):
+        raise RuntimeError(
+            f"Model path '{model_path}' does not exist. Configure WHISPER_MODEL_PATH to point to the downloaded weights."
+        )
+
+    return WhisperModel(model_path, device=device, compute_type=compute_type)
+
+
+@app.on_event("startup")
+async def _startup_event() -> None:
+    # Trigger model loading during startup so the first request does not pay the cost.
+    _load_model()
+
+
+@app.get("/healthz")
+async def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+def _resample_audio(samples: np.ndarray, source_rate: int, target_rate: int) -> np.ndarray:
+    if source_rate == target_rate or samples.size == 0:
+        return samples
+
+    duration_seconds = samples.shape[0] / float(source_rate)
+    target_length = max(1, int(math.ceil(duration_seconds * target_rate)))
+
+    source_indices = np.linspace(0, samples.shape[0] - 1, num=samples.shape[0], dtype=np.float64)
+    target_indices = np.linspace(0, samples.shape[0] - 1, num=target_length, dtype=np.float64)
+
+    resampled = np.interp(target_indices, source_indices, samples)
+    return resampled.astype(np.float32, copy=False)
+
+
+def _build_vosk_result(words: Iterable[dict]) -> List[dict]:
+    # Vosk uses "result" for word-level entries. Unity expects "word" and timing fields.
+    return list(words)
+
+
+@app.post("/transcribe")
+async def transcribe(
+    request: Request,
+    sample_rate: int = Query(DEFAULT_SAMPLE_RATE, ge=8000, le=48000),
+    language: Optional[str] = Query(None, min_length=1, max_length=8),
+    beam_size: int = Query(5, ge=1, le=10),
+    translate: bool = Query(False),
+) -> JSONResponse:
+    payload = await request.body()
+    if not payload:
+        raise HTTPException(status_code=400, detail="Empty audio payload")
+
+    audio = np.frombuffer(payload, dtype=np.int16)
+    if audio.size == 0:
+        raise HTTPException(status_code=400, detail="Invalid audio payload")
+
+    audio = audio.astype(np.float32) / 32768.0
+    if sample_rate != DEFAULT_SAMPLE_RATE:
+        audio = _resample_audio(audio, sample_rate, DEFAULT_SAMPLE_RATE)
+
+    model = _load_model()
+
+    task = "translate" if translate else "transcribe"
+    segments_generator, info = model.transcribe(
+        audio,
+        beam_size=beam_size,
+        language=language,
+        task=task,
+        word_timestamps=True,
+    )
+
+    segments = list(segments_generator)
+
+    words: List[dict] = []
+    combined_text_parts: List[str] = []
+
+    for segment in segments:
+        text = segment.text.strip()
+        if text:
+            combined_text_parts.append(text)
+
+        for word in segment.words or []:
+            word_text = word.word.strip()
+            if not word_text:
+                continue
+
+            words.append(
+                {
+                    "word": word_text,
+                    "start": max(0.0, float(word.start) if word.start is not None else 0.0),
+                    "end": max(0.0, float(word.end) if word.end is not None else 0.0),
+                    "confidence": round(float(word.probability), 4) if word.probability is not None else None,
+                }
+            )
+
+    full_text = " ".join(part for part in combined_text_parts if part).strip()
+    if not full_text and words:
+        full_text = " ".join(word["word"] for word in words).strip()
+
+    response = {
+        "text": full_text,
+        "result": _build_vosk_result(words),
+        "language": info.language,
+        "duration": info.duration,
+        "avg_logprob": info.avg_logprob,
+        "language_probability": info.language_probability,
+        "translation": translate,
+    }
+
+    return JSONResponse(response)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(_environment("PORT", "8000"))
+    uvicorn.run("main:app", host="0.0.0.0", port=port)

--- a/python_voice_service/requirements.txt
+++ b/python_voice_service/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+faster-whisper==0.10.0
+numpy==1.26.4


### PR DESCRIPTION
## Summary
- extend the Unity speech component with optional support for a Python speech service that posts microphone audio to Faster-Whisper and reuses the existing message hub flow
- add a FastAPI-based Python voice service, documentation, and ignore rules for virtual environments
- update the sample scene to enable the Python pipeline by default and document the setup in the README

## Testing
- python -m compileall python_voice_service

------
https://chatgpt.com/codex/tasks/task_e_68db02b3150083319998a5be24f7657a