### PR TITLE
Expand NuGet asset ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,28 @@ python_voice_service/.venv/
 python_voice_service/__pycache__/
 python_voice_service/.pytest_cache/
 
+# NuGet for Unity generated assets
+/[Aa]ssets/NuGetEditor/
+/[Aa]ssets/NuGetEditor.meta
+/[Aa]ssets/NuGet.config
+/[Aa]ssets/NuGet.config.meta
+/[Aa]ssets/NuGet/
+/[Aa]ssets/NuGet.meta
+/[Aa]ssets/packages.config
+/[Aa]ssets/packages.config.meta
+/[Aa]ssets/packages.lock.json
+/[Aa]ssets/packages.lock.json.meta
+
+# NuGet package downloads
+/[Aa]ssets/Packages/
+/[Aa]ssets/Packages.meta
+/[Aa]ssets/Plugins/System.Speech.dll
+/[Aa]ssets/Plugins/System.Speech.dll.meta
+/[Aa]ssets/Plugins/manifest.json
+/[Aa]ssets/Plugins/manifest.json.meta
+
+# Downloaded speech models
+/[Aa]ssets/StreamingAssets/vosk*
+/[Aa]ssets/StreamingAssets/vosk*/*.zip
+/[Aa]ssets/StreamingAssets/vosk*/*.zip.meta
+


### PR DESCRIPTION
## Summary
- ignore NuGet-generated folders, config metadata, and lock metadata files
- ignore NuGet plugin manifest artifacts alongside existing package payloads

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc087e05b88331a9deab1d901a5ca2