### PR TITLE
Add Ollama-backed coach response endpoint

### DIFF
--- a/python_voice_service/requirements.txt
+++ b/python_voice_service/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.110.0
 uvicorn[standard]==0.27.1
 faster-whisper==0.10.0
 numpy==1.26.4
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- add an async `/respond` endpoint that relays recognised text to an Ollama-hosted Llama 3.1 model
- expose configurable defaults for the coach system prompt and Ollama generation settings
- document the workflow and add the `httpx` client dependency for the Python voice service

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68dd25552d788331ab89b2d72f32581d