### PR TITLE
Ensure Windows speech initialization preserves default cultures

### DIFF
--- a/Assets/Scripts/VoiceGameLauncher.cs
+++ b/Assets/Scripts/VoiceGameLauncher.cs
@@ -411,10 +411,46 @@ namespace RobotVoice
                 return;
             }
 
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUiCulture = CultureInfo.CurrentUICulture;
+            var originalDefaultCulture = CultureInfo.DefaultThreadCurrentCulture;
+            var originalDefaultUiCulture = CultureInfo.DefaultThreadCurrentUICulture;
+
             try
             {
-                speechSynthesizer = new SpeechSynthesizer();
-                speechSynthesizer.SetOutputToDefaultAudioDevice();
+                try
+                {
+                    CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+                    CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+                    CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+                    CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+
+                    speechSynthesizer = new SpeechSynthesizer();
+                    speechSynthesizer.SetOutputToDefaultAudioDevice();
+                }
+                finally
+                {
+                    if (originalDefaultCulture != null)
+                    {
+                        CultureInfo.DefaultThreadCurrentCulture = originalDefaultCulture;
+                    }
+                    else
+                    {
+                        CultureInfo.DefaultThreadCurrentCulture = null;
+                    }
+
+                    if (originalDefaultUiCulture != null)
+                    {
+                        CultureInfo.DefaultThreadCurrentUICulture = originalDefaultUiCulture;
+                    }
+                    else
+                    {
+                        CultureInfo.DefaultThreadCurrentUICulture = null;
+                    }
+
+                    CultureInfo.CurrentCulture = originalCulture;
+                    CultureInfo.CurrentUICulture = originalUiCulture;
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- capture and restore thread and default cultures while creating the Windows speech synthesizer

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68dd967c20ec833191eed8b95eb0ad88