### PR TITLE
Add wake prompt flow for "hi rachel" and timed capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,14 @@ ProjectSettings/       # Unity project configuration
 
 ## Working with Robot_opr
 
-When the Unity client detects a wake word ("hey robot" by default) followed by
-an exercise command, `VoiceGameLauncher` publishes a JSON payload describing the
-request. The Robot_opr hub consumes the `LAUNCH_GAME` and `BACK_HOME` intent
-messages to start or exit the corresponding rehabilitation experience. You can
-customise wake words, synonyms and keyword lists through the inspector or by
-editing the JSON configuration asset assigned to the launcher component.
+When the Unity client detects the wake phrase ("hi rachel" by default) it
+responds with "What can I help you?" and opens a short five-second capture
+window for the follow-up instruction. If that instruction contains an exercise
+command, `VoiceGameLauncher` publishes a JSON payload describing the request.
+The Robot_opr hub consumes the `LAUNCH_GAME` and `BACK_HOME` intent messages to
+start or exit the corresponding rehabilitation experience. You can customise
+wake words, synonyms and keyword lists through the inspector or by editing the
+JSON configuration asset assigned to the launcher component.
 
 For richer interactions (e.g. free-form questions for the virtual coach) enable
 responses via the `/respond` endpoint exposed by the Python voice service. The


### PR DESCRIPTION
## Summary
- update the voice launcher to default to the "hi rachel" wake phrase, play the "What can I help you?" prompt, and open a five-second listening window
- add a Vosk speech service helper that restarts recording segments for the wake word window while preserving the original segment length afterwards
- document the new wake interaction flow in the project README

## Testing
- not run (Unity project, tests not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e42cc11ff88331ac6c2c22a442a339