### PR TITLE
Refactor voice service to gate Whisper behind Vosk wake word

### DIFF
--- a/python_voice_service/README.md
+++ b/python_voice_service/README.md
@@ -1,14 +1,18 @@
 # Python Voice Service
 
-This folder contains a lightweight FastAPI application that wraps the
+This folder contains a FastAPI application that combines
+[Vosk](https://alphacephei.com/vosk/) wake-word detection with the
 [Faster-Whisper](https://github.com/guillaumekln/faster-whisper) model
-so Unity can offload speech recognition to Python. The REST endpoint
-returns Vosk-compatible JSON payloads, allowing the existing
-`VoiceGameLauncher` logic to keep publishing intents to the message hub
-without any changes. A companion `/respond` endpoint can forward the
-transcribed text to a local [Ollama](https://ollama.com/) instance that
-runs Meta's Llama 3.1 model, enabling short spoken replies from the
-coach voice agent.
+so Unity can offload speech recognition to Python. Incoming audio first
+flows through a wake detector that is limited to pronunciation variants
+of the keyword “richel”. Only when a match is detected does the API
+issue a short-lived wake token. The follow-up transcription endpoint
+requires that token and returns a Vosk-compatible JSON payload, allowing
+the existing `VoiceGameLauncher` logic to keep publishing intents to the
+message hub without any changes. A companion `/respond` endpoint can
+forward the transcribed text to a local [Ollama](https://ollama.com/)
+instance that runs Meta's Llama 3.1 model, enabling short spoken replies
+from the coach voice agent.
 
 ## Requirements
 
@@ -18,6 +22,9 @@ coach voice agent.
   `D:/Data/unityproject/faster-whisper-large-v3` on Windows. Set the
   `WHISPER_MODEL_PATH` environment variable to that directory before
   starting the service.
+* A Vosk model folder for wake-word detection. Download one of the
+  English models (for example `vosk-model-small-en-us-0.15`) and set the
+  `VOSK_MODEL_PATH` environment variable to that directory.
 
 Install dependencies with:
 
@@ -53,14 +60,21 @@ pip install -r requirements.txt
    uvicorn main:app --host 0.0.0.0 --port 8000
    ```
 
-   The Unity scene expects the default URL `http://127.0.0.1:8000/transcribe`.
+   The Unity scene first calls `POST /wake` with continuous microphone
+   frames. When the response contains `"wake_word_detected": true`, play
+   `helper.mp3`, record five seconds of audio and send that recording to
+   `POST /transcribe` together with the `wake_token` value from the wake
+   response. The transcribe endpoint runs Faster-Whisper and returns the
+   familiar Vosk-style payload.
 
 3. Use the `/healthz` endpoint to confirm the service is ready.
 
-When Unity detects speech the `VoskSpeechToText` component serialises the
-PCM samples, posts them to `/transcribe` and reuses the JSON response to
-update the intent pipeline. No scene changes are required to keep
-publishing to the MQTT message hub.
+When Unity detects speech the `VoskSpeechToText` component should
+continuously serialise microphone frames to `/wake`. Once a wake token is
+issued, play `helper.mp3`, capture the follow-up clip and send it to
+`/transcribe` with the token. The JSON payload matches what the existing
+intent pipeline expects, so no downstream MQTT integration changes are
+required.
 
 ## Generating coach replies with Ollama
 

--- a/python_voice_service/requirements.txt
+++ b/python_voice_service/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.27.1
 faster-whisper==0.10.0
 numpy==1.26.4
 httpx==0.27.0
+vosk==0.3.45


### PR DESCRIPTION
## Summary
- add a Vosk-powered /wake endpoint that recognises Richel variants with limited keywords and issues short-lived wake tokens
- gate the Whisper transcription endpoint behind validated wake tokens so the heavy model only runs on follow-up audio
- document the new wake flow and declare the Vosk dependency for local setup

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e438b7043883318d9211b901acd956