### PR TITLE
Simplify Faster-Whisper transcription parameters

### DIFF
--- a/python_voice_service/main.py
+++ b/python_voice_service/main.py
@@ -208,13 +208,6 @@ async def transcribe(
         language=language or "en",
         task="transcribe",
         word_timestamps=True,
-        temperature=0.0,
-        compression_ratio_threshold=1.2,
-        log_prob_threshold=-0.45,
-        no_speech_threshold=0.75,
-        condition_on_previous_text=False,
-        vad_filter=True,
-        vad_parameters={"min_silence_duration_ms": 500},
     )
 
     segments = list(segments_generator)


### PR DESCRIPTION
## Summary
- remove custom thresholds and VAD options from the Faster-Whisper transcription call
- rely on the library defaults for beam search and word timestamps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52f7d17648331a472b0ce34136d09