### PR TITLE
Fix Piper HTTP wrapper to use correct Piper CLI flag

### DIFF
--- a/python_voice_service/piper_http.py
+++ b/python_voice_service/piper_http.py
@@ -32,7 +32,7 @@ def _build_command(text: str, out_path: Path) -> list[str]:
     model = _env("PIPER_MODEL_PATH")
     if not model:
         raise HTTPException(status_code=500, detail="PIPER_MODEL_PATH is not configured")
-    cmd = [exe, "--model", model, "--output_file", str(out_path), "--text", text]
+    cmd = [exe, "--model", model, "--output_file", str(out_path), "--input_text", text]
     cfg = _env("PIPER_CONFIG_PATH")
     if cfg:
         cmd += ["--config", cfg]


### PR DESCRIPTION
## Summary
- call Piper with the --input_text flag instead of the invalid --text flag
- ensure the HTTP wrapper can successfully generate audio output files

## Testing
- python -m compileall python_voice_service

------
https://chatgpt.com/codex/tasks/task_e_68e6862b751c8331b182f39e5a29a472